### PR TITLE
feat(devtools): install mosh across all profiles

### DIFF
--- a/docs/this_repo/tool-managers.md
+++ b/docs/this_repo/tool-managers.md
@@ -190,7 +190,7 @@ openvpn-connect, etc.) — uncomment to enable.
 Most CLI formulae land via ansible roles, not the Brewfile. Examples:
 
 - `base/tasks/main.yml`: `git`, `git-lfs`, `curl`, `wget`, `ripgrep`, `fd`, `jq`, `tree`, `just`
-- `devtools/tasks/main.yml`: large set — `bat`, `gh`, `glab`, `diffnav`, `git-delta`, `eza`, `tlrc`, `glow`, `gum`, `vhs`, `freeze`, `thefuck`, `zoxide`, `direnv`, `yazi`, `superfile`, `tmux`, `sesh`, `worktrunk`, `workmux`, `zellij`, `btop`, `htop`, `duckdb`, `rclone`, `coreutils`, `taplo`, `television`, `pandoc`, `tailspin`, `lnav`, `grc`, `dasel`, `yq`, `jnv`, `witr`, `figlet`, `toilet`, `lolcat`, `fastfetch`, `shellcheck`, `shfmt`, `bats-core`, `git-graph`
+- `devtools/tasks/main.yml`: large set — `bat`, `gh`, `glab`, `diffnav`, `git-delta`, `eza`, `tlrc`, `glow`, `gum`, `vhs`, `freeze`, `thefuck`, `zoxide`, `direnv`, `yazi`, `superfile`, `tmux`, `sesh`, `worktrunk`, `workmux`, `zellij`, `btop`, `htop`, `duckdb`, `rclone`, `coreutils`, `taplo`, `television`, `pandoc`, `tailspin`, `lnav`, `grc`, `dasel`, `yq`, `jnv`, `witr`, `figlet`, `toilet`, `lolcat`, `fastfetch`, `shellcheck`, `shfmt`, `bats-core`, `git-graph`, `mosh`
 - `coding_agents/tasks/main.yml`: `claude-code` (cask), `codex` (cask), `gemini-cli` (formula), `rtk` (formula), `specstory`, `codexbar`, `td`, `sidecar` (all with tap setup)
 - `networking_tools/`: `nmap`, `arp-scan`, `mtr`, `iperf3`, `doggo`, `httpie`, `gping`, `trippy`, `bandwhich`, `rustscan`, `speedtest` (tap `teamookla/speedtest`), `ngrok`, `cloudflared`
 - `media_tools/`: `ffmpeg`, `imagemagick`, `exiftool`, `vips`
@@ -1043,6 +1043,7 @@ list.
 | **mise** | curl `mise.run` | curl `mise.run` → direct binary → musl variant | bootstrap |
 | **mlflow** | uv tool | uv tool | python_uv_tools |
 | **models** | brew formula | Linuxbrew → cargo `modelsdev` | llm_tools |
+| **mosh** | brew | apt | devtools |
 | **mtr** | brew | apt/yum | networking_tools |
 | **nmap** | brew | apt/yum | networking_tools |
 | **neovim** | brew (`state: latest`) | apt → GitHub release → user → oldEL fork | neovim |

--- a/docs/this_repo/tool-managers.zh-TW.md
+++ b/docs/this_repo/tool-managers.zh-TW.md
@@ -184,7 +184,7 @@ Linux Brewfile 是空的,Linuxbrew 的使用是 role-by-role。
 大多數 CLI formulae 透過 ansible role 而非 Brewfile 安裝。例:
 
 - `base/tasks/main.yml`:`git`、`git-lfs`、`curl`、`wget`、`ripgrep`、`fd`、`jq`、`tree`、`just`
-- `devtools/tasks/main.yml`:大量集合——`bat`、`gh`、`glab`、`diffnav`、`git-delta`、`eza`、`tlrc`、`glow`、`gum`、`vhs`、`freeze`、`thefuck`、`zoxide`、`direnv`、`yazi`、`superfile`、`tmux`、`sesh`、`worktrunk`、`workmux`、`zellij`、`btop`、`htop`、`duckdb`、`rclone`、`coreutils`、`taplo`、`television`、`pandoc`、`tailspin`、`lnav`、`grc`、`dasel`、`yq`、`jnv`、`witr`、`figlet`、`toilet`、`lolcat`、`fastfetch`、`shellcheck`、`shfmt`、`bats-core`、`git-graph`
+- `devtools/tasks/main.yml`:大量集合——`bat`、`gh`、`glab`、`diffnav`、`git-delta`、`eza`、`tlrc`、`glow`、`gum`、`vhs`、`freeze`、`thefuck`、`zoxide`、`direnv`、`yazi`、`superfile`、`tmux`、`sesh`、`worktrunk`、`workmux`、`zellij`、`btop`、`htop`、`duckdb`、`rclone`、`coreutils`、`taplo`、`television`、`pandoc`、`tailspin`、`lnav`、`grc`、`dasel`、`yq`、`jnv`、`witr`、`figlet`、`toilet`、`lolcat`、`fastfetch`、`shellcheck`、`shfmt`、`bats-core`、`git-graph`、`mosh`
 - `coding_agents/tasks/main.yml`:`claude-code`(cask)、`codex`(cask)、`gemini-cli`(formula)、`rtk`(formula)、`specstory`、`codexbar`、`td`、`sidecar`(都有 tap 設定)
 - `networking_tools/`:`nmap`、`arp-scan`、`mtr`、`iperf3`、`doggo`、`httpie`、`gping`、`trippy`、`bandwhich`、`rustscan`、`speedtest`(tap `teamookla/speedtest`)、`ngrok`、`cloudflared`
 - `media_tools/`:`ffmpeg`、`imagemagick`、`exiftool`、`vips`
@@ -1004,6 +1004,7 @@ plugins 的推進。但 ~30 個 GitHub-release-installed CLI(其中很多廣泛
 | **mise** | curl `mise.run` | curl `mise.run` → 直接 binary → musl 變體 | bootstrap |
 | **mlflow** | uv tool | uv tool | python_uv_tools |
 | **models** | brew formula | Linuxbrew → cargo `modelsdev` | llm_tools |
+| **mosh** | brew | apt | devtools |
 | **mtr** | brew | apt/yum | networking_tools |
 | **nmap** | brew | apt/yum | networking_tools |
 | **neovim** | brew(`state: latest`) | apt → GitHub release → 使用者 → oldEL 分支 | neovim |

--- a/dot_ansible/roles/devtools/tasks/main.yml
+++ b/dot_ansible/roles/devtools/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Developer CLI tools role
-# Tools: bat, bats, gh, glab, diffnav, gh-dash, gh-notify, eza, git-delta, git-graph, tldr, glow, gum, vhs, freeze, thefuck, zoxide, direnv, yazi, superfile, tmux, sesh, worktrunk, workmux, zellij, herdr, btop, htop, duckdb, rclone, coreutils, taplo, television, pandoc, tailspin, lnav, grc, ccze (Linux only), dasel, yq, jnv, witr, figlet, toilet, lolcat, fastfetch
+# Tools: bat, bats, gh, glab, diffnav, gh-dash, gh-notify, eza, git-delta, git-graph, tldr, glow, gum, vhs, freeze, thefuck, zoxide, direnv, yazi, superfile, tmux, sesh, worktrunk, workmux, zellij, herdr, btop, htop, duckdb, rclone, coreutils, taplo, television, pandoc, tailspin, lnav, grc, ccze (Linux only), dasel, yq, jnv, witr, figlet, toilet, lolcat, fastfetch, mosh
 
 # =============================================================================
 # macOS - all via Homebrew
@@ -85,6 +85,10 @@
       - htop
       - duckdb
       - rclone
+      # mosh — mobile shell; roaming UDP-based SSH replacement that survives
+      # IP changes / sleep / high latency. mosh-server listens on UDP
+      # 60000-61000, which cloud hosts must open inbound.
+      - mosh
       - coreutils
       - taplo
       - television
@@ -2079,6 +2083,18 @@
 # --- thefuck ---
 # NOTE: thefuck is now installed via uv tool (python_uv_tools role)
 # This avoids conda/virtualenv Python path conflicts
+
+# --- mosh ---
+# mosh (mobile shell) — roaming UDP-based SSH replacement; survives IP
+# changes / sleep / high latency. In Debian/Ubuntu apt (universe). Note:
+# mosh-server listens on UDP 60000-61000, which cloud hosts must open inbound.
+- name: Install mosh (Debian/Ubuntu)
+  when: ansible_facts["os_family"] == "Debian"
+  become: true
+  tags: [sudo]
+  ansible.builtin.apt:
+    name: mosh
+    state: present
 
 # --- shellcheck + shfmt ---
 # Shell linting / formatting. macOS gets both via brew (block above).


### PR DESCRIPTION
## What

Install [mosh](https://mosh.org/) (mobile shell — roaming, UDP-based SSH replacement that survives IP changes, sleep, and high latency) on **all profiles** via the `devtools` role, which runs unconditionally on macOS + both Ubuntu profiles.

## Changes

- **`dot_ansible/roles/devtools/tasks/main.yml`**
  - macOS: `mosh` added to the Homebrew CLI-tools list
  - Debian/Ubuntu: dedicated `apt install mosh` task (universe), mirroring the existing `shellcheck` one-liner pattern
  - Header `# Tools:` comment updated
- **`docs/this_repo/tool-managers.md`** + **`.zh-TW` mirror** — A–Z index row `| **mosh** | brew | apt | devtools |` + devtools enumeration bullet (per CLAUDE.md cross-file rule)

## Scope

- Targets: macOS + `ubuntu_desktop` + `ubuntu_server`. RedHat/CentOS out of scope (no first-class profile; most of `devtools` only special-cases Debian + Darwin).
- **Firewall heads-up (not configured here):** `mosh-server` listens on UDP `60000–61000`; cloud/server hosts must open that range inbound for incoming mosh sessions.

## Verification

- `ansible-playbook playbooks/{linux,macos}.yml --syntax-check --tags devtools` → both pass
- YAML parses; new doc table rows validated (4 data cells, matching siblings)
- End-to-end on this macOS host: `brew info mosh` = valid formula (1.4.0, bottled); `mosh --version` → `mosh 1.4.0`; `mosh-server` binds UDP `60001` (confirms the documented port range). `state: present` is idempotent (already installed here).
- mkdocs `--strict` not run: change is row-only additions to existing in-nav pages (no new files/anchors/links); repo has a known baseline of ~12 strict warnings tracked in `backlog/mkdocs-anchor-drift.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)